### PR TITLE
Depend on NPM package instead of github

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "peerDependencies": {},
   "dependencies": {
     "extend": "^2.0.1",
-    "falafel-espree": "https://github.com/royriojas/falafel-espree/tarball/master",
+    "falafel-espree": "^1.1.0",
     "js-beautify": "^1.5.10"
   },
   "devDependencies": {


### PR DESCRIPTION
I'd like to be able to pull the 'standard' package into a package repository that's sitting behind a firewall, and at the moment I'm blocked because of the reference to github in package.json.