### PR TITLE
Fix the version of babylon in use

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   ],
   "peerDependencies": {},
   "dependencies": {
-    "babylon": "^6.1.21",
+    "babylon": "6.1.21",
     "esformatter-ignore": "^0.1.3",
     "extend": "^2.0.1",
     "fresh-falafel": "^1.2.0",


### PR DESCRIPTION
To avoid running into this bug: https://phabricator.babeljs.io/T6930

I'm not sure what is actually causing the problem, but I'm guessing it's a minor/patch upgrade version in babylon which is broken.

To clarify; here's the minimal reproduction case where I see this:

`package.json`

```json
{
  "name": "foo",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "ISC",
  "dependencies": {
    "browserify": "^13.0.0",
    "esformatter-jsx": "4.1.0"
  }
}
```

`index.js`
```javascript
require('html-to-react-components');
```

Then run:
```bash
./node_modules/.bin/browserify index.js > out.js
```

And get this error:

```
Error: Cannot find module './parser' from '/tmp/tmp6/node_modules/babylon'
    at /tmp/tmp6/node_modules/resolve/lib/async.js:55:21
    at load (/tmp/tmp6/node_modules/resolve/lib/async.js:69:43)
    at onex (/tmp/tmp6/node_modules/resolve/lib/async.js:92:31)
    at /tmp/tmp6/node_modules/resolve/lib/async.js:22:47
    at FSReqWrap.oncomplete (fs.js:82:15)

shell returned 1
```