### PR TITLE
Fix: jsx attr indents respect htmlOptions

### DIFF
--- a/lib/format-jsx.js
+++ b/lib/format-jsx.js
@@ -174,8 +174,11 @@ module.exports = {
               var first = node.attributes[ 0 ];
               var firstAttributeInSameLine = me.jsxOptions.firstAttributeOnSameLine;
 
-              var alignWith = me.jsxOptions.alignWithFirstAttribute ? first.loc.start.column : node.loc.start.column + htmlOptions.indent_size;
-              var tabPrefix = (new Array( alignWith + 1 )).join( htmlOptions.indent_char );
+              var indentSize = htmlOptions.indent_size || 4;
+              var indentChar = htmlOptions.indent_char || ' ';
+
+              var alignWith = me.jsxOptions.alignWithFirstAttribute ? first.loc.start.column : node.loc.start.column + indentSize;
+              var tabPrefix = (new Array( alignWith + 1 )).join( indentChar );
 
               var index = 0;
               //console.log( node.attributes );

--- a/lib/format-jsx.js
+++ b/lib/format-jsx.js
@@ -152,7 +152,7 @@ module.exports = {
         } );
         return removeEmptyLines( code.toString() );
       },
-      operateOnOpenTags: function ( source ) {
+      operateOnOpenTags: function ( source, htmlOptions ) {
         var me = this;
 
         // make sure tags are in a single line
@@ -174,8 +174,8 @@ module.exports = {
               var first = node.attributes[ 0 ];
               var firstAttributeInSameLine = me.jsxOptions.firstAttributeOnSameLine;
 
-              var alignWith = me.jsxOptions.alignWithFirstAttribute ? first.loc.start.column + 1 : node.loc.start.column + 3;
-              var tabPrefix = (new Array( alignWith )).join( ' ' );
+              var alignWith = me.jsxOptions.alignWithFirstAttribute ? first.loc.start.column : node.loc.start.column + htmlOptions.indent_size;
+              var tabPrefix = (new Array( alignWith + 1 )).join( htmlOptions.indent_char );
 
               var index = 0;
               //console.log( node.attributes );
@@ -251,7 +251,7 @@ module.exports = {
         source = beautifier.html( source, htmlOptions );
 
         if ( !jsxOptions.attrsOnSameLineAsTag ) {
-          source = me.operateOnOpenTags( source );
+          source = me.operateOnOpenTags( source, htmlOptions );
         }
 
         if ( !noAlign ) {

--- a/specs/compare.spec.js
+++ b/specs/compare.spec.js
@@ -46,7 +46,7 @@ describe( 'esformatter-jsx', function () {
         //console.log( '\n\n', actual, '\n\n' );
         //fs.writeFileSync('./specs/expected/' + path.basename(file), actual);
 
-        expect( expected ).to.equal( actual, 'file comparison failed: ' + file );
+        expect( actual ).to.equal( expected, 'file comparison failed: ' + file );
 
       } );
     } );

--- a/specs/expected/attribute-indents-respect-options.js
+++ b/specs/expected/attribute-indents-respect-options.js
@@ -1,0 +1,20 @@
+var React = require('react');
+
+var Hello = React.createClass({
+  render: function() {
+    return (
+      <ReactElement className='classes'
+          style={ style }
+          onClick={ this.click }
+          onMouseDown={ this.start }
+          onMouseMove={ this.move }
+          onMouseUp={ this.stop }>
+          <div>
+              Element
+          </div>
+      </ReactElement>
+      );
+  }
+});
+
+React.render(<Hello message="world" />, document.body);

--- a/specs/fixtures/attribute-indents-respect-options.js
+++ b/specs/fixtures/attribute-indents-respect-options.js
@@ -1,0 +1,20 @@
+var React = require('react');
+
+var Hello = React.createClass({
+  render: function() {
+    return (
+      <ReactElement className='classes'
+                         style={ style }
+                         onClick={ this.click }
+                         onMouseDown={ this.start }
+                         onMouseMove={ this.move }
+                         onMouseUp={ this.stop }>
+             <div>
+              Element
+          </div>
+           </ReactElement>
+           );
+  }
+});
+
+React.render(<Hello message="world" />, document.body);

--- a/specs/options/attribute-indents-respect-options.json
+++ b/specs/options/attribute-indents-respect-options.json
@@ -1,0 +1,11 @@
+{
+  "jsx": {
+    "attrsOnSameLineAsTag": false,
+    "firstAttributeOnSameLine": true,
+    "alignWithFirstAttribute": false,
+    "htmlOptions": {
+	  	"indent_size": 4,
+	  	"indent_char": " "
+	  }
+  }
+}


### PR DESCRIPTION
Previously, jsx attributes align either 2 spaces or with the first attribute. Now it aligns depending on values in htmlOptions.

Doesn't work properly if jsfmt is set to use tabs, but that was true regardless of this patch.