### PR TITLE
New option: closingTagOnNewLine

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ If you're running into troubles with the formatting applied to your files I foun
     "alignWithFirstAttribute": false, // do not align attributes with the first tag
     "spaceInJSXExpressionContainers": " ", // default to one space. Make it empty if you don't like spaces between JSXExpressionContainers
     "removeSpaceBeforeClosingJSX": false // default false. if true <React.Something /> => <React.Something/>
+    "closingTagOnNewLine": false, // default false. if true attributes on multiple lines will close the tag on a new line
     "htmlOptions": {
       // put here the options for js-beautify.html
     }

--- a/lib/format-jsx.js
+++ b/lib/format-jsx.js
@@ -194,8 +194,10 @@ module.exports = {
                 cNode.update( '\n' + tabPrefix + cNode.source() );
               } );
 
-              if (me.jsxOptions.closingTagOnNewLine) {
-                node.update(node.source().replace(/\>$/, '\n>'));
+              if ( me.jsxOptions.closingTagOnNewLine ) {
+                // If you find a closing tag (including a self-closing tag like />), add a new line, matching the current alignWith
+                var closingTagTabPrefix = (new Array( node.loc.start.column + 1 )).join( indentChar );
+                node.update( node.source().replace( /(\/?\>)$/, '\n' + closingTagTabPrefix + '$1' ) );
               }
             }
           }

--- a/lib/format-jsx.js
+++ b/lib/format-jsx.js
@@ -193,6 +193,10 @@ module.exports = {
 
                 cNode.update( '\n' + tabPrefix + cNode.source() );
               } );
+
+              if (me.jsxOptions.closingTagOnNewLine) {
+                node.update(node.source().replace(/\>$/, '\n>'));
+              }
             }
           }
 

--- a/specs/expected/bug-34.js
+++ b/specs/expected/bug-34.js
@@ -13,7 +13,7 @@ export /* from */ edfg
 /* from */ from /* from */
 'some-file'; /* from */ // some comment from john
 
-export * as some from 'here';
+export * as some3 from 'here';
 
 export class myClass {
   execute() {

--- a/specs/expected/closing-tag-on-new-line.js
+++ b/specs/expected/closing-tag-on-new-line.js
@@ -1,0 +1,21 @@
+function demo(someText) {
+  return (
+    <div
+      className='.classA'
+      data-attr1='stuff'
+      data-attr2='things'
+    >
+      <span
+        className='.classB'
+        data-attr3='attr3'
+      />
+      <div
+        className='.classC'
+        data-attr4='attr4'
+        data-attr5='attr5'
+      >
+        { someText }
+      </div>
+    </div>
+    );
+}

--- a/specs/fixtures/bug-34.js
+++ b/specs/fixtures/bug-34.js
@@ -12,7 +12,7 @@ export /* from */ edfg
 /* from */ from /* from */
 'some-file'; /* from */ // some comment from john
 
-export * as some from 'here';
+export * as some3 from 'here';
 
 export class myClass {
   execute() {

--- a/specs/fixtures/closing-tag-on-new-line.js
+++ b/specs/fixtures/closing-tag-on-new-line.js
@@ -1,0 +1,8 @@
+function demo(someText) {
+  return (
+    <div className='.classA' data-attr1='stuff' data-attr2='things'>
+      <span className='.classB' data-attr3='attr3'/>
+      <div className='.classC' data-attr4='attr4' data-attr5='attr5'>{someText}</div>
+    </div>
+    );
+}

--- a/specs/options/closing-tag-on-new-line.json
+++ b/specs/options/closing-tag-on-new-line.json
@@ -1,0 +1,9 @@
+{
+  "jsx": {
+    "alignWithFirstAttribute": false,
+    "attrsOnSameLineAsTag": false,
+    "firstAttributeOnSameLine": false,
+    "formatJSX": true,
+    "closingTagOnNewLine": true
+  }
+}


### PR DESCRIPTION
Fix for #67 .

If this option is true, multiline tags will have the closing tag on its own line.

Instead of: 
```
<div
  attr1='foo'
  attr2='bar'>
  A div.
</div>
```

You get:
```
<div
  attr1='foo'
  attr2='bar'
>
  A div.
</div>
```

This is not thoroughly tested, but works in my sample cases.